### PR TITLE
Configure for Binderhub

### DIFF
--- a/m9_q-learning.ipynb
+++ b/m9_q-learning.ipynb
@@ -62,16 +62,16 @@
    "outputs": [],
    "source": [
     "%%capture\n",
-    "!pip install pyglet==1.5.1 \n",
-    "!apt install python-opengl\n",
-    "!apt install ffmpeg\n",
-    "!apt install xvfb\n",
-    "!pip install pyvirtualdisplay\n",
-    "from ipywidgets import FloatProgress\n",
-    "from pyvirtualdisplay import Display\n",
+    "# !pip install pyglet==1.5.1 \n",
+    "# !apt install python-opengl\n",
+    "# !apt install ffmpeg\n",
+    "# !apt install xvfb\n",
+    "# !pip install pyvirtualdisplay\n",
+    "# from ipywidgets import FloatProgress\n",
+    "# from pyvirtualdisplay import Display\n",
     "\n",
-    "virtual_display = Display(visible=0, size=(1400, 900))\n",
-    "virtual_display.start()"
+    "# virtual_display = Display(visible=0, size=(1400, 900))\n",
+    "# virtual_display.start()"
    ]
   },
   {
@@ -91,6 +91,7 @@
     "!pip install gym==0.23\n",
     "!pip install pygame\n",
     "!pip install numpy\n",
+    "!pip install tqdm\n",
     "!pip install imageio imageio_ffmpeg"
    ]
   },


### PR DESCRIPTION
1. Install missing package `tqdm`.

2. Remove virtual display:
    The current code doesn't use virtual display, so it can be delete for now.
    The code cell of virtual display setup is for Google Colab, BinderHub does not support installing `apt` packages inside notebooks.
    Run the notebook on Google colab:
    https://colab.research.google.com/github/zauri/frozenlake/blob/main/m9_q-learning.ipynb